### PR TITLE
Create concatenator + refactor m

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,8 +12,8 @@ is_blob_identical: False
 shuffle_each_dataset_samples: True
 balanced: True
 splits: [0.55, 0.20, 0.25]
-n_dataset: 1000
-m: 100
+n_dataset: 500
+n_instances_per_dataset: 100
 n_features: 2
 
 seed: 0

--- a/config/grid_search_override.yaml
+++ b/config/grid_search_override.yaml
@@ -1,12 +1,11 @@
 project_name: [you_can_delete_this_project]
 run_name_content: [[has_skip_connection, has_batch_norm, lr]]
 
-dataset: [blob_and_moon]
+dataset: [moon]
 msg_size: ${mod_1_dim[0]}
 lr: [1e-2, 1e-3]
-has_skip_connection: [False, True]
-has_batch_norm: [False, True]
+has_batch_norm: [True]
 mod_1_dim:  [[50]]  # [[50], [100], [500], [1000]]
 mod_2_dim:  ${mod_1_dim}
 batch_size: [50]
-n_epoch: [10]
+n_epoch: [5]

--- a/src/data/create_datasets.py
+++ b/src/data/create_datasets.py
@@ -22,6 +22,6 @@ def create_datasets(config: dict):
         return load_mnist()
 
     if config["dataset"] in ["MTPL2_frequency", "MTPL2_severity", "MTPL2_pure"]:
-        return load_MTPL(config["dataset"][6:], config["n_dataset"], config["m"])
+        return load_MTPL(config["dataset"][6:], config["n_dataset"], config["n_instances_per_dataset"])
 
     raise NotImplementedError(f"The dataset '{config['dataset']}' is not supported.")

--- a/src/data/dataset/blob.py
+++ b/src/data/dataset/blob.py
@@ -20,10 +20,10 @@ def generate_blob_datasets(config: dict) -> np.ndarray:
 
 
 def generate_random_blob_dataset(config: dict) -> np.ndarray:
-    nb_of_samples_of_the_second_class = config["m"] // 2
+    nb_of_samples_of_the_second_class = config["n_instances_per_dataset"] // 2
 
     x_of_first_class = generate_random_blob_features(config)
-    y_of_first_class = np.ones((config["m"], 1))
+    y_of_first_class = np.ones((config["n_instances_per_dataset"], 1))
     x, y = modify_first_class_samples_to_add_the_second_class(x_of_first_class, y_of_first_class,
                                                               nb_of_samples_of_the_second_class)
 
@@ -36,7 +36,7 @@ def generate_random_blob_dataset(config: dict) -> np.ndarray:
 def generate_random_blob_features(config: dict) -> np.ndarray:
     random_gaussian_blob_center = np.random.rand(config["n_features"]) * 10 - 5
     return np.random.multivariate_normal(mean=random_gaussian_blob_center, cov=np.eye(config["n_features"]),
-                                         size=config["m"])
+                                         size=config["n_instances_per_dataset"])
 
 
 def modify_first_class_samples_to_add_the_second_class(x: np.ndarray, y: np.ndarray,

--- a/src/data/dataset/mnist.py
+++ b/src/data/dataset/mnist.py
@@ -8,7 +8,7 @@ def load_mnist():
     """
     Generates a set of 90 MNIST binary sub-problems
     return:
-        Numpy array of dims n x m x n_features
+        Numpy array of dims n x n_instances_per_dataset x n_features
     """
     # Loading the initial dataset
     transform = transforms.Compose([transforms.ToTensor()])

--- a/src/data/dataset/moon.py
+++ b/src/data/dataset/moon.py
@@ -23,7 +23,7 @@ def generate_moon_datasets(config: dict) -> np.ndarray:
 
 
 def generate_moon_dataset(config: dict) -> np.ndarray:
-    x, y = make_moons(config["m"], noise=0.08, random_state=config["seed"])
+    x, y = make_moons(config["n_instances_per_dataset"], noise=0.08, random_state=config["seed"])
     y[y == 0] = -1
 
     if config["shuffle_each_dataset_samples"]:

--- a/src/data/dataset/mtpl.py
+++ b/src/data/dataset/mtpl.py
@@ -5,15 +5,14 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer, StandardScaler, KBinsDiscretizer, OneHotEncoder
 
 
-def load_MTPL(task, n, m):
+def load_MTPL(task, n, n_instances_per_dataset):
     """
     Fetch the French Motor Third-Party Liability Claims dataset.
     Args:
         task (str): the task to perform on the MTPL2 dataset (choices: "frequency", "severity", "pure").
         n (int): Number of linearly separable datasets to create;
-        m (int): Number of examples per dataset.
     return:
-        Numpy array of dims n x m x n_features
+        Numpy array of dims n x n_instances_per_dataset x n_features
     """
     # freMTPL2freq dataset from https://www.openml.org/d/41214
     df_freq = fetch_openml(data_id=41214, as_frame=True).data
@@ -81,13 +80,13 @@ def load_MTPL(task, n, m):
         y = df["PurePremium"].to_numpy().reshape((-1, 1))
         weight = df["Exposure"].to_numpy().reshape((-1, 1))
     data = np.hstack((np.array(x), weight, y * 2 - 1)).astype(float, copy=False)
-    new_data, k = np.zeros((n, m, 77)), 0
+    new_data, k = np.zeros((n, n_instances_per_dataset, 77)), 0
     for i in range(len(df["Region"].cat.categories)):
         if k == n:
             break
         inds = df["Region"] == df["Region"].cat.categories[i]
-        for j in range(len(x[inds]) // m):
-            new_data[k] = data[inds][int(j * m): int((j + 1) * m)]
+        for j in range(len(x[inds]) // n_instances_per_dataset):
+            new_data[k] = data[inds][int(j * n_instances_per_dataset): int((j + 1) * n_instances_per_dataset)]
             k += 1
             if k == n:
                 break

--- a/src/data/utils.py
+++ b/src/data/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def create_empty_datasets(config: dict) -> np.ndarray:
     y_target_second_dim = 1
-    return np.zeros((config["n_dataset"], config["m"], config["n_features"] + y_target_second_dim))
+    return np.zeros((config["n_dataset"], config["n_instances_per_dataset"], config["n_features"] + y_target_second_dim))
 
 
 def shuffled_x_and_y(x: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,6 @@ def main(config_combinations: list[dict]) -> None:
                                                   "MTPL2_frequency", "MTPL2_severity", "MTPL2_pure");
 
         balanced (list of bool): whether to consider balanced datasets during forward pass losses computation;                                          
-        m (list of int): number of examples per dataset;
         n_features (list of int): dimension of each example;
         splits (list of [float, float, float]): train, valid and test proportion of the data;
         meta_pred (list of str): meta_predictor to use (choices: "simplenet");
@@ -43,7 +42,7 @@ def main(config_combinations: list[dict]) -> None:
         if config["dataset"] == "mnist":
             # For non-synthetic data, these are fixed
             config["n_dataset"] = 90
-            config["m"] = 6313 * 2
+            config["n_instances_per_dataset"] = 6313 * 2
             config["n_features"] = 784
         elif config["dataset"] in ["MTPL2_frequency", "MTPL2_severity", "MTPL2_pure"]:
             # For non-synthetic data, these are fixed

--- a/src/model/custom_attention.py
+++ b/src/model/custom_attention.py
@@ -7,15 +7,14 @@ from src.model.mlp import MLP
 
 
 class CA(nn.Module):
-    def __init__(self, input_dim, hidden_dims_mlp, hidden_dims_kme, m, device: str, init_scheme: str,
-                 has_skip_connection: bool, has_batch_norm: bool, pooling_type: str, temp) -> None:
+    def __init__(self, input_dim, hidden_dims_mlp, hidden_dims_kme, n_instances_per_class_per_dataset: int, device: str,
+                 init_scheme: str, has_skip_connection: bool, has_batch_norm: bool, pooling_type: str, temp) -> None:
         """
         Initialize a custom attention head.
         Args:
             input_dim (int): input dimension of the custom attention head;
             hidden_dims_mlp (list of int): architecture of the MLP;
             hidden_dims_kme (list of int): architecture of the embedding (MLP) in the KME;
-            m (int): number of examples per dataset;
             pooling_type (str): type of pooling to apply for the query computation
             temp (float): temperature parameter for the softmax computation.
         """
@@ -27,7 +26,8 @@ class CA(nn.Module):
         if pooling_type == "kme":
             self.q = KME(input_dim, hidden_dims_kme, device, init_scheme, has_skip_connection, has_batch_norm)
         elif pooling_type == "fspool":
-            self.q = FSPool(input_dim, hidden_dims_kme, m, device, init_scheme, has_skip_connection, has_batch_norm)
+            self.q = FSPool(input_dim, hidden_dims_kme, n_instances_per_class_per_dataset, device, init_scheme,
+                            has_skip_connection, has_batch_norm)
         elif pooling_type == "none":
             self.q = MLP(input_dim, hidden_dims_kme, device, has_skip_connection, has_batch_norm, "cnt", init_scheme)
         else:

--- a/src/model/data_compressor/concatenator.py
+++ b/src/model/data_compressor/concatenator.py
@@ -1,0 +1,21 @@
+import torch
+
+
+class Concatenator:
+    def __init__(self, config: dict) -> None:
+        self.device = config["device"]
+
+    def forward(self, datasets: torch.Tensor) -> torch.Tensor:
+        n_instances_per_dataset_dim_idx = 1
+        shuffled_datasets_by_instance_per_dataset = self.shuffle(datasets, n_instances_per_dataset_dim_idx)
+        target_idx = -1
+        x = shuffled_datasets_by_instance_per_dataset[:, :, :target_idx]
+
+        return x.flatten(n_instances_per_dataset_dim_idx)
+
+    def shuffle(self, instances: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        random_indices = torch.randperm(instances.shape[dim])
+        if self.device == "gpu":
+            random_indices = random_indices.cuda()
+
+        return instances.index_select(dim, random_indices)

--- a/src/model/data_compressor/create_data_compressor.py
+++ b/src/model/data_compressor/create_data_compressor.py
@@ -1,3 +1,4 @@
+from src.model.data_compressor.concatenator import Concatenator
 from src.model.data_compressor.kme import KME
 
 
@@ -7,5 +8,8 @@ def create_data_compressor_1(config: dict):
     if data_compressor_name == "KME":
         return KME(config["n_features"] + 1, config["data_compressor_dim"], config["device"], config["init_scheme"],
                    config["has_skip_connection"], config["has_batch_norm"])
+
+    if data_compressor_name == "concatenator":
+        return Concatenator(config)
 
     raise NotImplementedError(f"'{data_compressor_name}' is not supported.")

--- a/src/model/data_compressor/fspool.py
+++ b/src/model/data_compressor/fspool.py
@@ -5,18 +5,17 @@ from src.model.mlp import MLP
 
 
 class FSPool(nn.Module):
-    def __init__(self, input_dim, hidden_dims, m, device: str, init_scheme: str, has_skip_connection: bool,
+    def __init__(self, input_dim, hidden_dims, n_instances_per_class_per_dataset, device: str, init_scheme: str, has_skip_connection: bool,
                  has_batch_norm: bool) -> None:
         """
         Initialize .
         Args:
             input_dim (int): input dimension of the custom attention head;
             hidden_dims (list of int): architecture of the embedding;
-            m (int): number of examples per dataset;
         """
         super(FSPool, self).__init__()
         self.mlp = MLP(input_dim - 1, hidden_dims, device, has_skip_connection, has_batch_norm, 'cnt', init_scheme)
-        self.mat = torch.rand((m, hidden_dims[-1]))
+        self.mat = torch.rand((n_instances_per_class_per_dataset, hidden_dims[-1]))
         if device == 'gpu':
             self.mat = self.mat.to('cuda:0')
 

--- a/src/model/data_compressor/kme.py
+++ b/src/model/data_compressor/kme.py
@@ -24,5 +24,4 @@ class KME(nn.Module):
         """
         x_1 = x[:, :, :-1].clone()
         out = self.embedding.forward(x_1)
-        x_1 = torch.mean(out * torch.reshape(x[:, :, -1], (len(x), -1, 1)), dim=1)  # ... A compression is done
-        return torch.reshape(x_1, (x_1.shape[0], 1, -1))
+        return torch.mean(out * torch.reshape(x[:, :, -1], (len(x), -1, 1)), dim=1)

--- a/src/model/predictor.py
+++ b/src/model/predictor.py
@@ -91,7 +91,7 @@ class Predictor(nn.Module):
             inputs (): ;
             return_sign (bool): whether to round the predictions or not.
         Return:
-            torch.Tensor of dims (batch_size, m, output_dims), the predictions.
+            torch.Tensor of dims (batch_size, n_instances_per_dataset, output_dims), the predictions.
         """
         out = 0
         if self.pred_type == "linear_classif":

--- a/src/model/simple_meta_net.py
+++ b/src/model/simple_meta_net.py
@@ -14,51 +14,42 @@ class SimpleMetaNet(nn.Module):
         Args:
             pred_input_dim (int): Input dimension of the predictor;
             config (dictionary) containing the following:
-                m (int): Number of examples per dataset;
-                n_features (int): Input dimension of each dataset;
                 comp_set_size (int): compression set size;
                 ca_dim (list of int): custom attention's MLP architecture;
                 mod_1_dim (list of int): MLP #1 architecture;
                 mod_2_dim (list of int): MLP #2 architecture;
                 tau (int): temperature parameter (softmax in custom attention);
-                batch_size (int): Batch size.
         """
         super(SimpleMetaNet, self).__init__()
-        self.device = config["device"]
         self.comp_set_size = config["comp_set_size"]
         self.msg_size = config["msg_size"]
-        self.ca_dim = config["ca_dim"]
-        self.msg_size = config["msg_size"]
-        self.mod_1_dim = config["mod_1_dim"] + [self.msg_size]
-        self.mod_2_dim = config["mod_2_dim"]
-        self.m = int(config["m"] / 2)
         self.msg_type = config["msg_type"]
-        self.init_scheme = config["init_scheme"]
+        self.n_instances_per_class_per_dataset = config["n_instances_per_dataset"] // 2
+        self.mod_1_dim = config["mod_1_dim"] + [self.msg_size]
         self.msg = torch.tensor(0.0)  # Message (compression selection)
         self.msk = None  # Mask (compression selection)
-        self.n_features = config["n_features"]
-        self.tau = config["tau"]
-        self.batch_size = config["batch_size"]
-        self.input_dim = self.n_features
+        self.input_dim = config["n_features"]
         self.output_dim = pred_input_dim
         self.mod_2_input = config["data_compressor_dim"][-1] * (self.comp_set_size > 0) + self.mod_1_dim[-1] * (
                 self.msg_size > 0)
 
         # Generating the many components (custom attention (CA) multi-heads, KME #1-2, MLP #1-2) of the meta-learner
-        self.kme_1 = create_data_compressor_1(config)
-        self.mod_1 = MLP(config["data_compressor_dim"][-1], self.mod_1_dim, self.device, config["has_skip_connection"],
-                         config["has_batch_norm"], self.msg_type, self.init_scheme)
+        self.data_compressor_1 = create_data_compressor_1(config)
+        self.mod_1 = MLP(config["data_compressor_dim"][-1], self.mod_1_dim, config["device"],
+                         config["has_skip_connection"],
+                         config["has_batch_norm"], config["msg_type"], config["init_scheme"])
 
         self.cas = nn.ModuleList([])
         for i in range(self.comp_set_size):
-            self.cas.append(CA(self.n_features + 1, self.ca_dim, self.ca_dim, self.m, self.device,
-                               self.init_scheme, config["has_skip_connection"], config["has_batch_norm"], "fspool",
-                               self.tau))
-        self.kme_2 = KME(self.n_features + 1, config["data_compressor_dim"], self.device, self.init_scheme,
-                         config["has_skip_connection"], config["has_batch_norm"])
+            self.cas.append(
+                CA(config["n_features"] + 1, config["ca_dim"], config["ca_dim"], config["n_instances_per_dataset"] // 2,
+                   config["device"], config["init_scheme"], config["has_skip_connection"], config["has_batch_norm"],
+                   "fspool", config["tau"]))
+        self.kme_2 = KME(config["n_features"] + 1, config["data_compressor_dim"], config["device"],
+                         config["init_scheme"], config["has_skip_connection"], config["has_batch_norm"])
 
-        self.mod_2 = MLP(self.mod_2_input, self.mod_2_dim + [self.output_dim], self.device,
-                         config["has_skip_connection"], config["has_batch_norm"], "none", self.init_scheme)
+        self.mod_2 = MLP(self.mod_2_input, config["mod_2_dim"] + [self.output_dim], config["device"],
+                         config["has_skip_connection"], config["has_batch_norm"], "none", config["init_scheme"])
 
     def forward(self, x, n_samples=0):
         """
@@ -72,11 +63,9 @@ class SimpleMetaNet(nn.Module):
         # Message computation #
         x_ori = x.clone()
         if self.msg_size > 0:
-
-            # Passing through KME #1 #
-            x = self.kme_1.forward(x)
+            x = self.data_compressor_1.forward(x)
             # Passing through MLP #1 #
-            x = self.mod_1.forward(torch.reshape(x, (len(x), -1)))
+            x = self.mod_1.forward(x)
 
             if self.msg_type == "cnt":
                 x = x * 3  # See bound computation

--- a/src/model/utils/loss.py
+++ b/src/model/utils/loss.py
@@ -5,8 +5,8 @@ def lin_loss(output, targets):
     """
     Computes the linear loss.
     Args:
-        output (torch.tensor of size (batch_size, m)): The output (0 or 1) of the predictor;
-        targets (torch.tensor of size (batch_size, m)): The labels (0 or 1);
+        output (torch.tensor of size (batch_size, n_instances_per_dataset)): The output (0 or 1) of the predictor;
+        targets (torch.tensor of size (batch_size, n_instances_per_dataset)): The labels (0 or 1);
     Return:
         Float, the total linear loss incurred.
     """
@@ -28,7 +28,7 @@ def l1(x, c):
     """
     Computes the l1 loss, given inputs and a regularization parameter.
     Args:
-        x (torch.tensor of size m): Inputs
+        x (torch.tensor of size n_instances_per_dataset): Inputs
         c (float): Regularization parameter
     Return:
         Float, the l1 loss
@@ -40,7 +40,7 @@ def l2(x, c):
     """
     Computes the l1 loss, given inputs and a regularization parameter.
     Args:
-        x (torch.tensor of size m): Inputs
+        x (torch.tensor of size n_instances_per_dataset): Inputs
         c (float): Regularization parameter
     Return:
         Float, the l2 loss

--- a/src/result/compute_stats.py
+++ b/src/result/compute_stats.py
@@ -5,14 +5,14 @@ import torch
 
 from src.bound.compute_bound import compute_bound
 from src.model.predictor import Predictor
+from src.model.simple_meta_net import SimpleMetaNet
 from src.model.utils.loss import lin_loss
 
 
-def stats(meta_pred, pred: Predictor, criterion, data_loader, msg_type, device):
+def stats(meta_pred: SimpleMetaNet, pred: Predictor, criterion, data_loader, msg_type, device):
     """
     Computes the overall accuracy, loss and bounds of a predictor on given task and dataset.
     Args:
-        meta_pred (nn.Module): A meta predictor (neural network) to train.
         criterion (torch.nn, function): Loss function
         data_loader (DataLoader): A DataLoader to test on.
         msg_type (str): type of message (choices: 'dsc' (discrete), 'cnt' (continuous));
@@ -22,8 +22,8 @@ def stats(meta_pred, pred: Predictor, criterion, data_loader, msg_type, device):
     """
     bnd_lin, bnd_hyp, bnd_kl, bnd_mrch = [], [], [], []  # The various bounds to compute
     meta_pred.eval()  # We put the meta predictor in evaluation mode
-    m = meta_pred.m
-    with torch.no_grad():
+    n_instances_per_class_per_dataset = meta_pred.n_instances_per_class_per_dataset
+    with (torch.no_grad()):
         i, k = 0, 0  # Number of batches / examples we have been through
         tot_loss, tot_acc = [], []
         for inputs in data_loader:
@@ -34,17 +34,23 @@ def stats(meta_pred, pred: Predictor, criterion, data_loader, msg_type, device):
             inputs, targets = inputs.float(), targets.float()
             if str(device) == 'gpu':
                 inputs, targets, meta_pred = inputs.cuda(), targets.cuda(), meta_pred.cuda()
-            meta_output = meta_pred(inputs[:, :m])  # Computing the parameters of the predictor
+            meta_output = meta_pred(
+                inputs[:, :n_instances_per_class_per_dataset])  # Computing the parameters of the predictor
             pred.set_weights(meta_output, len(inputs))  # Updating the weights of the predictor
-            output = pred.forward(inputs[:, m:], True)  # Computing the predictions for the task
-            loss = criterion(output[0], targets[:, m:])  # Loss computation
+            output = pred.forward(inputs[:, n_instances_per_class_per_dataset:],
+                                  True)  # Computing the predictions for the task
+            loss = criterion(output[0], targets[:, n_instances_per_class_per_dataset:])  # Loss computation
             tot_loss.append(torch.sum(loss).cpu())
-            acc = m * lin_loss(output[1], targets[:, m:] * 2 - 1)  # Accuracy computation
-            tot_acc.append(torch.mean(acc / m).cpu())
+            acc = n_instances_per_class_per_dataset * lin_loss(output[1],
+                                                               targets[:, n_instances_per_class_per_dataset:] * 2 - 1)
+            tot_acc.append(torch.mean(acc / n_instances_per_class_per_dataset).cpu())
             if msg_type is not None:
                 for b in range(len(inputs)):  # For all datasets, we compute the bounds
-                    bnds = compute_bound(['linear', 'hyperparam', 'kl', 'marchand'], meta_pred, pred, m,
-                                         m - acc.item(), 0.05, 0, 1, inputs[[b], m:], targets[[b], m:])
+                    bnds = compute_bound(['linear', 'hyperparam', 'kl', 'marchand'], meta_pred, pred,
+                                         n_instances_per_class_per_dataset,
+                                         n_instances_per_class_per_dataset - acc.item(), 0.05, 0, 1,
+                                         inputs[[b], n_instances_per_class_per_dataset:],
+                                         targets[[b], n_instances_per_class_per_dataset:])
                     bnd_lin.append(bnds[0])
                     bnd_hyp.append(bnds[1])
                     bnd_kl.append(bnds[2])


### PR DESCRIPTION
### Changes

Refactor some stuff

- Create the `Concatenator` : a data compressor module that simply concatenate and shuffle the inputs (an alternative to the KME and FSPOOL)
- Rename `m` by `n_instances_per_dataset`. I didn't rename them all because sometimes `m` refers to `n_instances_per_class_per_dataset`. Therefore, I renamed some `m` to `n_instances_per_class_per_dataset`, but I didn't to it for all of them. You might need to give a look. :eyes: 

### Quick results
#### KME
![image](https://github.com/GRAAL-Research/DeepRM/assets/88633026/0ef41bc0-18fe-47fc-b989-e02523a700a9)
#### Concatenator
![image](https://github.com/GRAAL-Research/DeepRM/assets/88633026/51fafc75-34c7-4e70-9de2-e9340190b506)
