### PR TITLE
Fix batch norm

### DIFF
--- a/src/model/lazy_batch_norm.py
+++ b/src/model/lazy_batch_norm.py
@@ -3,45 +3,50 @@ from torch import nn as nn
 
 
 class LazyBatchNorm(nn.Module):
-    def __init__(self, device: str = "cpu", *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, device: str) -> None:
+        super().__init__()
         self.device = device
-        self.used = False
         self.gamma = None
         self.beta = None
         self.last_mean = None
         self.last_std = None
         self.last_gamma = None
         self.last_beta = None
+        self.epsilon = 1e-10
 
-    def forward(self, x, use_last_values=False, save_bn_params=False):
-        """
-        Computes a forward pass, given an input.
-        Args:
-            x (torch.tensor of floats): input;
-            use_last_values (bool): whether to use previously saved means and stds;
-            save_bn_params (bool): whether to save the computed means and stda for future use with same parameters;
-        return:
-            torch.Tensor: output of the custom attention heads layer.
-        """
-        if not self.used:   # For the first usage, the dims are stored; scale and offsets are initialized
-            shape = [1] * (len(x.shape) - 1) + [x.shape[-1]]
-            self.gamma = torch.normal(1, torch.ones(shape) * 1e-5)
-            self.beta = torch.normal(0, torch.ones(shape) * 1e-5)
+    def initialize_gamma_and_beta(self, x_shape: torch.Size) -> None:
+        params_shape = [1] * (len(x_shape) - 1) + [x_shape[-1]]
+        epsilon = 1e-5
+        std = torch.ones(params_shape) * epsilon
+        self.gamma = nn.Parameter(torch.normal(mean=1, std=std))
+        self.beta = nn.Parameter(torch.normal(mean=0, std=std))
+
+        if self.device == "gpu":
+            self.cuda()
+
+    def forward(self, x: torch.Tensor, is_using_saved_stats: bool = False,
+                is_saving_computed_stats: bool = False) -> torch.Tensor:
+        if self.gamma is None and self.beta is None:
+            self.initialize_gamma_and_beta(x.shape)
+
+        if is_using_saved_stats:
+            return (x - self.last_mean) / (self.last_std + self.epsilon) * self.last_gamma + self.last_beta
+
+        new_mean = x.mean(dim=1, keepdim=True)
+        new_std = self.compute_safe_std(x, dim=1)
+        if is_saving_computed_stats:
+            self.last_mean = new_mean.clone()
+            self.last_std = new_std.clone()
+            self.last_gamma = self.gamma.clone()
+            self.last_beta = self.beta.clone()
+
+        return (x - new_mean) / (new_std + self.epsilon) * self.gamma + self.beta
+
+    def compute_safe_std(self, x: torch.Tensor, dim: int) -> torch.Tensor:
+        if x.shape[dim] == 1:
+            standard_deviation = torch.zeros(x.size())
             if self.device == "gpu":
-                self.gamma = self.gamma.to(device='cuda:0')
-                self.beta = self.beta.to(device='cuda:0')
-            self.used = True
-        if use_last_values:     # Whether to use previously saved means and stds
-            return (x - self.last_mean) / (self.last_std + 1e-10) * \
-                self.last_gamma + self.last_beta
-        else:
-            if save_bn_params:  # Whether to save the computed means and stds for future use with same parameters
-                self.last_mean = x.mean(dim=1, keepdim=True)
-                self.last_std = x.std(dim=1, keepdim=True)
-                self.last_gamma = self.gamma.clone()
-                self.last_beta = self.beta.clone()
-                return ((x - torch.mean(x, dim=1, keepdim=True)) / (torch.std(x, dim=1, keepdim=True) + 1e-10) *
-                        self.gamma + self.beta)
-            return ((x - torch.mean(x, dim=1, keepdim=True)) / (torch.std(x, dim=1, keepdim=True) + 1e-10) *
-                    self.gamma + self.beta)
+                standard_deviation = standard_deviation.cuda()
+            return standard_deviation
+
+        return x.std(dim=dim, keepdim=True)

--- a/src/model/predictor/small_neural_network.py
+++ b/src/model/predictor/small_neural_network.py
@@ -67,9 +67,9 @@ class SmallNeuralNetwork(Predictor):
 
             elif isinstance(layer, LazyBatchNorm):
                 if self.use_last_values:
-                    x = layer.forward(x, use_last_values=self.use_last_values)
+                    x = layer.forward(x, is_using_saved_stats=self.use_last_values)
                 elif self.save_bn_params:
-                    x = layer.forward(x, save_bn_params=self.save_bn_params)
+                    x = layer.forward(x, is_saving_computed_stats=self.save_bn_params)
                 else:
                     x = layer.forward(x)
 


### PR DESCRIPTION
Handles the case where there is only one element in the computation of the std. We can now use messages of length 1 :tada: I also refactored the code.