### PR TITLE
CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,9 +3,7 @@ title: >-
   Software for the article "Generalization Bounds via
   Meta-Learned Model Representations: PAC-Bayes and Sample
   Compression Hypernetworks"
-message: >-
-  message: "If you use this software, please cite it as
-  below."
+message: "If you use this software, please cite it as below."
 type: software
 authors:
   - given-names: Benjamin
@@ -27,8 +25,10 @@ authors:
   - given-names: Pascal
     family-names: Germain
     affiliation: Laval University
+    email: pascal.germain@ift.ulaval.ca
+repository-code: "https://github.com/GRAAL-Research/DeepRM"
 preferred-citation:
-  type: article
+  type: conference-paper
   authors:
   - given-names: Benjamin
     family-names: Leblanc
@@ -49,8 +49,11 @@ preferred-citation:
   - given-names: Pascal
     family-names: Germain
     affiliation: Laval University
+    email: pascal.germain@ift.ulaval.ca
   doi: "10.48550/arXiv.2410.13577"
-  journal: "ICML 2025"
   title: "Generalization Bounds via Meta-Learned Model Representations: PAC-Bayes and Sample Compression Hypernetworks"
-  abstract: "Both PAC-Bayesian and Sample Compress learning frameworks are instrumental for deriving tight (non-vacuous) generalization bounds for neural networks. We leverage these results in a meta-learning scheme, relying on a hypernetwork that outputs the parameters of a downstream predictor from a dataset input. The originality of our approach lies in the investigated hypernetwork architectures that encode the dataset before decoding the parameters: (1) a PAC-Bayesian encoder that expresses a posterior distribution over a latent space, (2) a Sample Compress encoder that selects a small sample of the dataset input along with a message from a discrete set, and (3) a hybrid between both approaches motivated by a new Sample Compress theorem handling continuous messages. The latter theorem exploits the pivotal information transiting at the encoder-decoder junction in order to compute generalization guarantees for each downstream predictor obtained by our meta-learning scheme. "
-  url: "https://github.com/GRAAL-Research/DeepRM"
+  conference:
+    name: "International Conference on Machine Learning"
+    abbreviation: "ICML"
+  url: "https://arxiv.org/abs/2410.13577"
+  year: 2025

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+title: >-
+  Software for the article "Generalization Bounds via
+  Meta-Learned Model Representations: PAC-Bayes and Sample
+  Compression Hypernetworks"
+message: >-
+  message: "If you use this software, please cite it as
+  below."
+type: software
+authors:
+  - given-names: Benjamin
+    family-names: Leblanc
+    affiliation: Laval University
+    email: benjamin.leblanc.2@ulaval.ca
+  - given-names: Mathieu
+    family-names: Bazinet
+    affiliation: Laval University
+    email: mathieu.bazinet.2@ulaval.ca
+  - given-names: Nathaniel
+    family-names: D'Amours
+    affiliation: Laval University
+    email: nathaniel.damours.1@ulaval.ca
+  - given-names: Alexandre
+    family-names: Drouin
+    affiliation: 'ServiceNow Research, Laval University'
+    email: alexandre.drouin@servicenow.com
+  - given-names: Pascal
+    family-names: Germain
+    affiliation: Laval University
+preferred-citation:
+  type: article
+  authors:
+  - given-names: Benjamin
+    family-names: Leblanc
+    affiliation: Laval University
+    email: benjamin.leblanc.2@ulaval.ca
+  - given-names: Mathieu
+    family-names: Bazinet
+    affiliation: Laval University
+    email: mathieu.bazinet.2@ulaval.ca
+  - given-names: Nathaniel
+    family-names: D'Amours
+    affiliation: Laval University
+    email: nathaniel.damours.1@ulaval.ca
+  - given-names: Alexandre
+    family-names: Drouin
+    affiliation: 'ServiceNow Research, Laval University'
+    email: alexandre.drouin@servicenow.com
+  - given-names: Pascal
+    family-names: Germain
+    affiliation: Laval University
+  doi: "10.48550/arXiv.2410.13577"
+  journal: "ICML 2025"
+  title: "Generalization Bounds via Meta-Learned Model Representations: PAC-Bayes and Sample Compression Hypernetworks"
+  abstract: "Both PAC-Bayesian and Sample Compress learning frameworks are instrumental for deriving tight (non-vacuous) generalization bounds for neural networks. We leverage these results in a meta-learning scheme, relying on a hypernetwork that outputs the parameters of a downstream predictor from a dataset input. The originality of our approach lies in the investigated hypernetwork architectures that encode the dataset before decoding the parameters: (1) a PAC-Bayesian encoder that expresses a posterior distribution over a latent space, (2) a Sample Compress encoder that selects a small sample of the dataset input along with a message from a discrete set, and (3) a hybrid between both approaches motivated by a new Sample Compress theorem handling continuous messages. The latter theorem exploits the pivotal information transiting at the encoder-decoder junction in order to compute generalization guarantees for each downstream predictor obtained by our meta-learning scheme. "
+  url: "https://github.com/GRAAL-Research/DeepRM"


### PR DESCRIPTION
We can now cite this repo with two clicks :
![image](https://github.com/user-attachments/assets/54257e50-239a-4e1f-b37c-c4dc85f0e8e3)

Here is the bibtex entry generated :
```bib
@inproceedings{Leblanc_Generalization_Bounds_via_2025,
author = {Leblanc, Benjamin and Bazinet, Mathieu and D'Amours, Nathaniel and Drouin, Alexandre and Germain, Pascal},
doi = {10.48550/arXiv.2410.13577},
series = {International Conference on Machine Learning},
title = {{Generalization Bounds via Meta-Learned Model Representations: PAC-Bayes and Sample Compression Hypernetworks}},
url = {https://arxiv.org/abs/2410.13577},
year = {2025}
}
```

Docs on CITATION.CFF : https://citation-file-format.github.io/